### PR TITLE
Fix datetime handling in Ticket API

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from auth import verify_password, create_access_token
 from models import Base, Ticket,User
 import requests
 import shutil
-from datetime import timedelta
+from datetime import datetime, timedelta
 import os
 from fastapi.middleware.cors import CORSMiddleware
 Base.metadata.create_all(bind=engine)
@@ -36,8 +36,8 @@ class TicketCreate(BaseModel):
     code: Optional[str]
     city: Optional[str]
     status: Optional[str]
-    entry_time: Optional[str]
-    exit_time: Optional[str]
+    entry_time: Optional[datetime]
+    exit_time: Optional[datetime]
     entry_pic_url: Optional[HttpUrl]
     car_pic_base64: str
     exit_video_url: Optional[HttpUrl]
@@ -50,8 +50,8 @@ class TicketOut(BaseModel):
     code: Optional[str] = None
     city: Optional[str] = None
     status: Optional[str] = None
-    entry_time: Optional[str] = None
-    exit_time: Optional[str] = None
+    entry_time: Optional[datetime] = None
+    exit_time: Optional[datetime] = None
     entry_pic_path: Optional[str] = None
     car_pic: Optional[str] = None
     exit_video_path: Optional[str] = None
@@ -115,7 +115,7 @@ def create_ticket(ticket: TicketCreate, db: Session = Depends(get_db)):
         code=ticket.code,
         city=ticket.city,
         status=ticket.status,
-        entry_time=ticket.entry_time,
+        entry_time=ticket.entry_time or datetime.utcnow(),
         exit_time=ticket.exit_time,
         entry_pic_path=entry_pic_path,
         car_pic=ticket.car_pic_base64,


### PR DESCRIPTION
## Summary
- treat entry and exit times as datetimes
- default `entry_time` to current time when missing

## Testing
- `python -m py_compile main.py models.py auth.py database.py seed_admin.py`

------
https://chatgpt.com/codex/tasks/task_e_68762f26fb808326a0d11662867fd6a8