### PR TITLE
Add submit API to integrate park-in/out

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
-from fastapi import FastAPI, HTTPException, Depends,FastAPI, UploadFile, File
+from fastapi import FastAPI, HTTPException, Depends, UploadFile, File
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel
 from typing import Optional, List
 from sqlalchemy.orm import Session
 from database import SessionLocal, engine
 from auth import verify_password, create_access_token
-from models import Base, Ticket,User
+from models import Base, Ticket, User
 import requests
 import shutil
 from datetime import datetime, timedelta
@@ -13,8 +13,8 @@ import os
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-import os
 import uuid
+from parking_api import park_in_request, park_out_request
 Base.metadata.create_all(bind=engine)
 app = FastAPI()
 cors_env = os.environ.get("CORS_ORIGINS")
@@ -146,3 +146,44 @@ async def upload_video(file: UploadFile = File(...)):
         "message": "Video uploaded successfully",
         "file_name": unique_filename
     })
+
+
+@app.post("/submit/{ticket_id}")
+def submit_ticket(ticket_id: int, db: Session = Depends(get_db)):
+    """Submit a ticket by calling park-in then park-out APIs."""
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    parkin_resp = park_in_request(
+        token=ticket.token,
+        parkin_time=(ticket.entry_time or datetime.utcnow()).isoformat(),
+        plate_code=ticket.code or "",
+        plate_number=ticket.number or "",
+        emirates=ticket.city or "",
+        conf=str(ticket.ticket_key_id or ""),
+        spot_number=ticket.spot_number or 0,
+        pole_id=ticket.access_point_id or 0,
+        images=[ticket.entry_pic_base64] if ticket.entry_pic_base64 else [],
+    )
+
+    trip_id = None
+    if isinstance(parkin_resp, dict):
+        trip_id = parkin_resp.get("trip_id") or parkin_resp.get("data", {}).get("trip_id")
+    if not trip_id:
+        raise HTTPException(status_code=400, detail="Failed to obtain trip id")
+
+    ticket.trip_p_id = trip_id
+    ticket.status = "submitted"
+    db.commit()
+    db.refresh(ticket)
+
+    parkout_resp = park_out_request(
+        token=ticket.token,
+        parkout_time=(ticket.exit_time or datetime.utcnow()).isoformat(),
+        spot_number=ticket.spot_number or 0,
+        pole_id=ticket.access_point_id or 0,
+        trip_id=trip_id,
+    )
+
+    return {"park_in": parkin_resp, "park_out": parkout_resp, "ticket_id": ticket.id}

--- a/parking_api.py
+++ b/parking_api.py
@@ -1,0 +1,73 @@
+import os
+import json
+import time
+import requests
+from typing import List, Any, Dict
+
+PARKONIC_BASE_URL = os.environ.get("PARKONIC_BASE_URL", "")
+
+
+def send_request_with_retry(url: str, payload: Dict[str, Any], retries: int = 3, delay: float = 1.0) -> Dict[str, Any] | str:
+    """Send POST request with retries."""
+    for attempt in range(retries):
+        try:
+            response = requests.post(url, json=payload, timeout=10)
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:  # broad catch to mirror simple behaviour
+            last_exc = exc
+            time.sleep(delay)
+    # if all retries failed, return error message
+    return str(last_exc)
+
+
+def park_in_request(
+    token: str,
+    parkin_time: str,
+    plate_code: str,
+    plate_number: str,
+    emirates: str,
+    conf: str,
+    spot_number: int,
+    pole_id: int,
+    images: List[str],
+) -> Dict[str, Any]:
+    """Call the /park-in endpoint."""
+    url = f"{PARKONIC_BASE_URL}/park-in"
+    payload = {
+        "token": token,
+        "parkin_time": str(parkin_time),
+        "plate_code": plate_code,
+        "plate_number": plate_number,
+        "emirates": emirates,
+        "conf": conf,
+        "spot_number": spot_number,
+        "pole_id": pole_id,
+        "images": images,
+    }
+    resp = send_request_with_retry(url, payload)
+    if isinstance(resp, str):
+        try:
+            resp = json.loads(resp)
+        except Exception:
+            resp = {}
+    return resp
+
+
+def park_out_request(token: str, parkout_time: str, spot_number: int, pole_id: int, trip_id: int) -> Dict[str, Any]:
+    """Call the /park-out endpoint."""
+    url = f"{PARKONIC_BASE_URL}/park-out"
+    payload = {
+        "token": token,
+        "parkout_time": str(parkout_time),
+        "spot_number": str(spot_number),
+        "pole_id": pole_id,
+        "trip_id": str(trip_id),
+    }
+    resp = send_request_with_retry(url, payload)
+    if isinstance(resp, str):
+        try:
+            resp = json.loads(resp)
+        except Exception:
+            resp = {}
+    return resp


### PR DESCRIPTION
## Summary
- call Parkonic entry/exit APIs via new `parking_api.py`
- create `/submit/{ticket_id}` endpoint that triggers the entry request, saves trip id, updates ticket status, then calls park-out

## Testing
- `python -m py_compile main.py parking_api.py auth.py database.py models.py seed_admin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d47122e08326855633242637c076