### PR TITLE
Add pagination and list endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,8 +119,9 @@ def normalize_path_car(path: str) -> str:
     return path
 
 @app.get("/tickets/", response_model=List[TicketOut])
-def get_tickets(db: Session = Depends(get_db)):
-    tickets = db.query(Ticket).all()
+def get_tickets(page: int = 1, page_size: int = 10, db: Session = Depends(get_db)):
+    offset = (page - 1) * page_size
+    tickets = db.query(Ticket).offset(offset).limit(page_size).all()
     return tickets
 @app.get("/tickets/next-id")
 def get_next_ticket_id(db: Session = Depends(get_db)):
@@ -128,6 +129,18 @@ def get_next_ticket_id(db: Session = Depends(get_db)):
     max_id = db.query(func.max(Ticket.id)).scalar()
     next_id = (max_id or 0) + 1
     return {"next_id": next_id}
+
+@app.get("/submittedtickets/", response_model=List[TicketOut])
+def get_submitted_tickets(page: int = 1, page_size: int = 10, db: Session = Depends(get_db)):
+    offset = (page - 1) * page_size
+    tickets = db.query(SubmittedTicket).offset(offset).limit(page_size).all()
+    return tickets
+
+@app.get("/cancelledtickets/", response_model=List[TicketOut])
+def get_cancelled_tickets(page: int = 1, page_size: int = 10, db: Session = Depends(get_db)):
+    offset = (page - 1) * page_size
+    tickets = db.query(CancelledTicket).offset(offset).limit(page_size).all()
+    return tickets
 @app.post("/login")
 def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     user = db.query(User).filter(User.username == form_data.username).first()


### PR DESCRIPTION
## Summary
- add pagination to GET /tickets
- implement listing for submitted and cancelled tickets

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887394e81248326806df6549c48d34a