### PR TITLE
Implement convert-video processing

### DIFF
--- a/convert_video.py
+++ b/convert_video.py
@@ -1,35 +1,24 @@
-# import ffmpeg
-# import os
-# def make_browser_friendly(input_path, output_path):
-#     if os.path.isfile(input_path):
-#             print("Valid")
-#     else:
-#             print("Not Valid")
-#     (
-#         ffmpeg
-#         .input(input_path)
-#         .output(output_path, c_v='libx264', preset='fast', crf=23, movflags='+faststart', c_a='aac')
-#         .run(overwrite_output=True)
-#     )
-
-# make_browser_friendly("D:/exit_video/0dc88677-eabf-4752-9160-08a738e9621b.mp4", "test/good_video.mp4")
-
 import os
-import ffmpeg
-
-# Set path to ffmpeg.exe explicitly
-os.environ["PATH"] += os.pathsep + r"C:/ffmpeg/bin/ffmpeg.exe"
-
-def make_browser_friendly(input_path, output_path):
-    (
-        ffmpeg
-        .input(input_path)
-        .output(output_path, vcodec='libx264', preset='fast', crf=23, movflags='+faststart', acodec='aac')
-        .run(overwrite_output=True)
-    )
 import subprocess
 
-def make_browser_friendly(input_path, output_path):
+
+def make_browser_friendly(input_path: str) -> str:
+    """Convert a video to a browser friendly format in the same directory.
+
+    Parameters
+    ----------
+    input_path : str
+        Absolute path to the video.
+
+    Returns
+    -------
+    str
+        Path to the converted video. The original file is removed.
+    """
+    directory, filename = os.path.split(input_path)
+    base, ext = os.path.splitext(filename)
+    output_path = os.path.join(directory, f"{base}_bf{ext}")
+
     cmd = [
         "ffmpeg",
         "-i", input_path,
@@ -38,15 +27,11 @@ def make_browser_friendly(input_path, output_path):
         "-crf", "23",
         "-movflags", "+faststart",
         "-c:a", "aac",
-        output_path
+        output_path,
     ]
+
     subprocess.run(cmd, check=True)
 
-make_browser_friendly(
-    "test/0bbc1335-004b-44c3-bf23-d53292f798e4.mp4",
-    "test/0bbc1335-004b-44c3-bf23-d53292f798e41.mp4"
-)
-# make_browser_friendly(
-#     "D:/exit_video/0dc88677-eabf-4752-9160-08a738e9621b.mp4",
-#     "test/good_video.mp4"
-# )
+    os.remove(input_path)
+    return output_path
+


### PR DESCRIPTION
## Summary
- clean up `convert_video.py` and provide a `make_browser_friendly` helper
- add `normalize_video_path` helper and update imports
- implement `/convert-video/{token}` endpoint to convert stored videos and update DB

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889f3cbf460832688c1066efe87ff73