### PR TITLE
Handle ticket re-entry after long gap

### DIFF
--- a/main.py
+++ b/main.py
@@ -243,6 +243,11 @@ def create_ticket(ticket: TicketCreate, db: Session = Depends(get_db)):
         .first()
     )
 
+    if existing and existing.exit_time and ticket.entry_time:
+        time_diff = ticket.entry_time - existing.exit_time
+        if time_diff > timedelta(hours=2):
+            existing = None
+
     if existing:
         latest = (
             db.query(Ticket)


### PR DESCRIPTION
## Summary
- Treat ticket submissions over two hours after the last exit as new tickets

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c7c2d667488326a4a0cc3964e34152