### PR TITLE
Handle empty API responses gracefully

### DIFF
--- a/parking_api.py
+++ b/parking_api.py
@@ -9,17 +9,36 @@ PARKONIC_BASE_URL = "https://api.parkonic.com/api/street-parking/v2"
 
 
 def send_request_with_retry(url: str, payload: Dict[str, Any], retries: int = 3, delay: float = 1.0) -> Dict[str, Any] | str:
-    """Send POST request with retries."""
+    """Send POST request with retries.
+
+    The upstream API occasionally returns an empty body with a ``200`` status,
+    which causes ``response.json()`` to raise a ``JSONDecodeError``. We treat
+    that as a soft failure and return a structured error dictionary instead of
+    bubbling up the decoding exception.
+    """
+
+    last_exc: Exception | None = None
+
     for attempt in range(retries):
         try:
             response = requests.post(url, json=payload, timeout=10)
             response.raise_for_status()
-            return response.json()
+
+            try:
+                return response.json()
+            except ValueError as exc:
+                # Empty or non-JSON response body
+                last_exc = exc
+                content = response.text.strip()
+                if content:
+                    return {"error": "Invalid JSON response", "raw": content}
+                return {"error": "Empty response body"}
         except Exception as exc:  # broad catch to mirror simple behaviour
             last_exc = exc
             time.sleep(delay)
+
     # if all retries failed, return error message
-    return str(last_exc)
+    return str(last_exc) if last_exc else {}
 
 
 def park_in_request(


### PR DESCRIPTION
## Summary
- handle empty or invalid JSON responses from the Parkonic API by returning structured error details
- prevent JSON decoding failures from bubbling up when posting to park-in and park-out endpoints

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eb294b4408326a5082df63dd5eaec)